### PR TITLE
feat: 차량 등록 CRUD 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,9 +39,12 @@ dependencies {
 
 	// QueryDSL
 	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+	// ModelMapper
+	implementation 'org.modelmapper:modelmapper:3.1.1'
 
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.25.7'

--- a/backend/src/main/java/dev/kimbank/iload/config/ModelMapperConfig.java
+++ b/backend/src/main/java/dev/kimbank/iload/config/ModelMapperConfig.java
@@ -1,0 +1,19 @@
+package dev.kimbank.iload.config;
+
+import org.modelmapper.ModelMapper;
+import org.modelmapper.convention.MatchingStrategies;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+    @Bean
+    public ModelMapper modelMapper() {
+        ModelMapper mapper = new ModelMapper();
+        mapper.getConfiguration()
+                .setMatchingStrategy(MatchingStrategies.STRICT)
+                .setFieldMatchingEnabled(true)
+                .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE);
+        return mapper;
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/config/QueryDslConfig.java
+++ b/backend/src/main/java/dev/kimbank/iload/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package dev.kimbank.iload.config;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(this.entityManager);
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/VehicleController.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/VehicleController.java
@@ -1,0 +1,64 @@
+package dev.kimbank.iload.domain.vehicle;
+
+import dev.kimbank.iload.domain.vehicle.dto.*;
+import dev.kimbank.iload.domain.vehicle.entity.*;
+import dev.kimbank.iload.global.security.AuthedUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.*;
+import lombok.*;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/vehicle")
+@RequiredArgsConstructor
+@Tag(name="Vehicle", description = "차량 관련 API")
+class VehicleController {
+    private final VehicleService vehicleService;
+
+    @GetMapping("/in-progress-cards")
+    @Operation(summary = "미완성 차량 등록 카드 조회",
+            description = "사용자가 미완성 상태로 남긴 차량 등록 카드 목록을 조회합니다.")
+    public List<RegisterVehicleInProgressCardResponse> getRegisterVehicleInProgressCard(
+            @AuthedUser Long userId) {
+        return vehicleService.getRegisterVehicleInProgressCard(userId);
+    }
+
+    @PostMapping("/create-empty")
+    @Operation(summary = "비어있는 차량 등록 생성",
+            description = "사용자의 ID를 기반으로 비어있는 차량 등록을 생성합니다.")
+    public Long createEmptyRegisteredVehicle(
+            @AuthedUser Long userId) {
+        return vehicleService.createEmptyRegisteredVehicle(userId);
+    }
+
+    @GetMapping
+    @Operation(summary = "차량 등록 상세 조회",
+            description = "차량 등록 ID를 기반으로 차량 등록의 상세 정보를 조회합니다.")
+    public RegisteredVehicle getRegisteredVehicle(
+            @AuthedUser Long userId,
+            @RequestParam Long id) {
+        return vehicleService.getRegisteredVehicle(userId, id);
+    }
+
+    @PutMapping("/basic-info")
+    @Operation(summary = "차량 등록 기본 정보 업데이트",
+            description = "차량 등록 ID와 사용자 ID를 기반으로 차량 등록의 기본 정보를 업데이트합니다.")
+    public void updateRegisteredVehicleBasicInfo(
+            @AuthedUser Long userId,
+            @RequestParam Long id,
+            @RequestBody VehicleRegistrationBasicInfoRequest request) {
+        vehicleService.updateRegisteredVehicleBasicInfo(userId, id, request);
+    }
+
+    @PutMapping("/etc-info")
+    @Operation(summary = "차량 등록 기타 정보 업데이트",
+            description = "차량 등록 ID와 사용자 ID를 기반으로 차량 등록의 기타 정보를 업데이트합니다.")
+    public void updateRegisteredVehicleEtcInfo(
+            @AuthedUser Long userId,
+            @RequestParam Long id,
+            @RequestBody VehicleRegistrationEtcInfoRequest request) {
+        vehicleService.updateRegisteredVehicleEtcInfo(userId, id, request);
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/VehicleService.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/VehicleService.java
@@ -1,0 +1,103 @@
+package dev.kimbank.iload.domain.vehicle;
+
+import dev.kimbank.iload.domain.users.UsersRepository;
+import dev.kimbank.iload.domain.users.entity.Users;
+import dev.kimbank.iload.domain.vehicle.dto.*;
+import dev.kimbank.iload.domain.vehicle.entity.*;
+import dev.kimbank.iload.domain.vehicle.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+class VehicleService {
+    private final VehicleQueryRepository vehicleQueryRepository;
+    private final RegisteredVehicleRepository registeredVehicleRepository;
+    private final UsersRepository usersRepository;
+    private final ModelMapper modelMapper;
+
+    // 비어있는 "등록 차량" 생성
+    public Long createEmptyRegisteredVehicle(Long userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없음: " + userId));
+
+        RegisteredVehicle vehicle = new RegisteredVehicle();
+        vehicle.setUsers(user);
+
+        registeredVehicleRepository.save(vehicle);
+
+        return vehicle.getId();
+    }
+
+    // 차량 등록 페이지에서 미완성된 "등록 차량" 목록 조회
+    public List<RegisterVehicleInProgressCardResponse> getRegisterVehicleInProgressCard(Long userId) {
+        List<RegisterVehicleInProgressCardResponse> vehicles = vehicleQueryRepository
+                .findRegisterVehicleInProgressCard(userId);
+
+        // 각 차량에 대해 진행 단계 및 총 단계를 설정
+        for (RegisterVehicleInProgressCardResponse vehicle : vehicles) {
+            vehicle.setProgressStep(1);
+            vehicle.setProgressTotalSteps(3);
+        }
+
+        return vehicles;
+    }
+
+    // "등록 차량" 상세 조회
+    public RegisteredVehicle getRegisteredVehicle(Long userId, Long vehicleId) {
+        // 차량이 해당 유저의 차량인지 확인
+        RegisteredVehicle vehicle = registeredVehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new IllegalArgumentException("등록 차량을 찾을 수 없음: " + vehicleId));
+
+        if (!vehicle.getUsers().getId().equals(userId)) {
+            throw new IllegalArgumentException("해당 차량은 조회할 수 없습니다.");
+        }
+
+        return vehicle;
+    }
+
+    // "등록 차량" 기본 정보 업데이트
+    public void updateRegisteredVehicle(Long userId, Long vehicleId) {
+        RegisteredVehicle existingVehicle = registeredVehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new IllegalArgumentException("등록 차량을 찾을 수 없음: " + vehicleId));
+
+        if (!existingVehicle.getUsers().getId().equals(userId)) {
+            throw new IllegalArgumentException("해당 차량은 수정할 수 없습니다.");
+        }
+
+        registeredVehicleRepository.save(existingVehicle);
+    }
+
+    // "등록 차량" 기타 정보 업데이트
+    public void updateRegisteredVehicleBasicInfo(Long userId, Long vehicleId,
+            VehicleRegistrationBasicInfoRequest request) {
+        RegisteredVehicle existingVehicle = registeredVehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new IllegalArgumentException("등록 차량을 찾을 수 없음: " + vehicleId));
+
+        if (!existingVehicle.getUsers().getId().equals(userId)) {
+            throw new IllegalArgumentException("해당 차량은 수정할 수 없습니다.");
+        }
+
+        modelMapper.map(request, existingVehicle);
+
+        registeredVehicleRepository.save(existingVehicle);
+    }
+
+    // "등록 차량" 기타 정보 업데이트
+    public void updateRegisteredVehicleEtcInfo(Long userId, Long vehicleId,
+            VehicleRegistrationEtcInfoRequest request) {
+        RegisteredVehicle existingVehicle = registeredVehicleRepository.findById(vehicleId)
+                .orElseThrow(() -> new IllegalArgumentException("등록 차량을 찾을 수 없음: " + vehicleId));
+
+        if (!existingVehicle.getUsers().getId().equals(userId)) {
+            throw new IllegalArgumentException("해당 차량은 수정할 수 없습니다.");
+        }
+
+        modelMapper.map(request, existingVehicle);
+
+        registeredVehicleRepository.save(existingVehicle);
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/RegisterVehicleInProgressCardResponse.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/RegisterVehicleInProgressCardResponse.java
@@ -1,0 +1,28 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Setter
+@Getter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class RegisterVehicleInProgressCardResponse implements Serializable {
+    Long id;
+    Long usersId;
+    String username;
+    Integer progressStep;
+    Integer progressTotalSteps;
+    ManufacturerEnum manufacturer;
+    Integer releaseYear;
+    Integer mileage;
+    Integer price;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/RegisteredVehicleCardResponse.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/RegisteredVehicleCardResponse.java
@@ -1,0 +1,33 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+public class RegisteredVehicleCardResponse implements Serializable {
+    Long id;
+    Long usersId;
+    String username;
+    ManufacturerEnum manufacturer;
+    Integer releaseYear;
+    Integer mileage;
+    Integer price;
+    List<RegisteredVehiclePhotoDto> photos;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+
+    /**
+     * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehiclePhoto}
+     */
+    @Value
+    public static class RegisteredVehiclePhotoDto implements Serializable {
+        String url;
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationAllInfoResponse.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationAllInfoResponse.java
@@ -1,0 +1,42 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.NoArgsConstructor;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+@NoArgsConstructor(force = true)
+public class VehicleRegistrationAllInfoResponse implements Serializable {
+    Long usersId;
+    VehicleTypeEnum vehicleType;
+    Integer displacement;
+    Integer seaterCount;
+    FuelTypeEnum fuelType;
+    String vehicleCode;
+    String vehicleNumber;
+    ManufactureCountryEnum manufactureCountry;
+    String vehicleGrade;
+    Integer releasePrice;
+    Integer mileage;
+    Integer releaseYear;
+    Integer manufactureYear;
+    AccidentInfoEnum accidentInfo;
+    RepaintedEnum repainted;
+
+    DriveTypeEnum driveType;
+    TransmissionEnum transmission;
+    ColorEnum color;
+    LocalDateTime initialRegistrationDate;
+    SpecialUseHistoryEnum specialUseHistory;
+    SpecialModificationHistoryEnum specialModificationHistory;
+    OptionInfoEnum optionInfo;
+
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationBasicInfoRequest.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationBasicInfoRequest.java
@@ -1,0 +1,27 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+public class VehicleRegistrationBasicInfoRequest implements Serializable {
+    VehicleTypeEnum vehicleType;
+    Integer displacement;
+    Integer seaterCount;
+    FuelTypeEnum fuelType;
+    String vehicleCode;
+    String vehicleNumber;
+    ManufactureCountryEnum manufactureCountry;
+    String vehicleGrade;
+    Integer releasePrice;
+    Integer mileage;
+    Integer releaseYear;
+    Integer manufactureYear;
+    AccidentInfoEnum accidentInfo;
+    RepaintedEnum repainted;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationBasicInfoResponse.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationBasicInfoResponse.java
@@ -1,0 +1,28 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.Value;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+public class VehicleRegistrationBasicInfoResponse implements Serializable {
+    Long usersId;
+    VehicleTypeEnum vehicleType;
+    Integer displacement;
+    Integer seaterCount;
+    FuelTypeEnum fuelType;
+    String vehicleCode;
+    String vehicleNumber;
+    ManufactureCountryEnum manufactureCountry;
+    String vehicleGrade;
+    Integer releasePrice;
+    Integer mileage;
+    Integer releaseYear;
+    Integer manufactureYear;
+    AccidentInfoEnum accidentInfo;
+    RepaintedEnum repainted;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationEtcInfoRequest.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationEtcInfoRequest.java
@@ -1,0 +1,22 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+public class VehicleRegistrationEtcInfoRequest implements Serializable {
+    Long usersId;
+    DriveTypeEnum driveType;
+    TransmissionEnum transmission;
+    ColorEnum color;
+    LocalDateTime initialRegistrationDate;
+    SpecialUseHistoryEnum specialUseHistory;
+    SpecialModificationHistoryEnum specialModificationHistory;
+    OptionInfoEnum optionInfo;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationEtcInfoResponse.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/dto/VehicleRegistrationEtcInfoResponse.java
@@ -1,0 +1,22 @@
+package dev.kimbank.iload.domain.vehicle.dto;
+
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import lombok.Value;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+/**
+ * DTO for {@link dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle}
+ */
+@Value
+public class VehicleRegistrationEtcInfoResponse implements Serializable {
+    Long usersId;
+    DriveTypeEnum driveType;
+    TransmissionEnum transmission;
+    ColorEnum color;
+    LocalDateTime initialRegistrationDate;
+    SpecialUseHistoryEnum specialUseHistory;
+    SpecialModificationHistoryEnum specialModificationHistory;
+    OptionInfoEnum optionInfo;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/RegisteredVehicle.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/RegisteredVehicle.java
@@ -1,0 +1,142 @@
+package dev.kimbank.iload.domain.vehicle.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.kimbank.iload.domain.users.entity.Users;
+import dev.kimbank.iload.domain.vehicle.entity.enums.*;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "registered_vehicle")
+public class RegisteredVehicle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "registered_vehicle_id", nullable = false)
+    private Long id;
+
+    @JsonIgnore // JSON 직렬화에서 제외 (순환 참조 방지)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "users_id", nullable = false)
+    @Comment("작성 유저 ID")
+    private Users users;
+
+    @Comment("제조 기업")
+    @Column(name = "manufacturer")
+    private ManufacturerEnum manufacturer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "vehicle_type")
+    @Comment("차량 유형")
+    private VehicleTypeEnum vehicleType;
+
+    @Column(name = "displacement")
+    @Comment("배기량")
+    private Integer displacement;
+
+    @Column(name = "seater_count")
+    @Comment("승차 인원")
+    private Integer seaterCount;
+
+    @Column(name = "fuel_type")
+    @Comment("연료")
+    private FuelTypeEnum fuelType;
+
+    @Column(name = "vehicle_code")
+    @Comment("차대번호")
+    private String vehicleCode;
+
+    @Column(name = "vehicle_number")
+    @Comment("차량 번호 ex) 123가 4567")
+    private String vehicleNumber;
+
+    @Column(name = "manufacture_country")
+    @Comment("제조 국가")
+    private ManufactureCountryEnum manufactureCountry;
+
+    @Column(name = "vehicle_grade")
+    @Comment("차량등급")
+    private String vehicleGrade;
+
+    @Column(name = "release_price")
+    @Comment("출고가격")
+    private Integer releasePrice;
+
+    @Column(name = "mileage")
+    @Comment("주행거리")
+    private Integer mileage;
+
+    @Column(name = "release_year")
+    @Comment("연식")
+    private Integer releaseYear;
+
+    @Column(name = "manufacture_year")
+    @Comment("제조 년도")
+    private Integer manufactureYear;
+
+    @Column(name = "accident_info")
+    @Comment("사고 정보")
+    private AccidentInfoEnum accidentInfo;
+
+    @Column(name = "repainted")
+    @Comment("도색 여부")
+    private RepaintedEnum repainted;
+
+    @Column(name = "drive_type")
+    @Comment("구동 방식")
+    private DriveTypeEnum driveType;
+
+    @Column(name = "transmission")
+    @Comment("변속기")
+    private TransmissionEnum transmission;
+
+    @Column(name = "color")
+    @Comment("색상")
+    private ColorEnum color;
+
+    @Column(name = "initial_registration_date")
+    @Comment("최초 등록")
+    private LocalDateTime initialRegistrationDate;
+
+    @Column(name = "special_use_history")
+    @Comment("특수 사용 이력")
+    private SpecialUseHistoryEnum specialUseHistory;
+
+    @Column(name = "special_modification_history")
+    @Comment("특수 개조 내역")
+    private SpecialModificationHistoryEnum specialModificationHistory;
+
+    @Column(name = "option_info")
+    @Comment("옵션 정보")
+    private OptionInfoEnum optionInfo;
+
+    @OneToMany(mappedBy = "registeredVehicle", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @Comment("차량 등록증")
+    private List<VehicleRegistrationCertificate> vehicleRegistrationCertificates;
+
+    @OneToMany(mappedBy = "registeredVehicle", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @Comment("등록된 차량 사진")
+    private List<RegisteredVehiclePhoto> registeredVehiclePhotos;
+
+    @Column(name = "selling_price")
+    @Comment("판매 희망 가격")
+    private Integer sellingPrice;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    @Comment("등록 일시")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    @Comment("수정 일시")
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/RegisteredVehiclePhoto.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/RegisteredVehiclePhoto.java
@@ -1,6 +1,5 @@
-package dev.kimbank.iload.domain.users.entity;
+package dev.kimbank.iload.domain.vehicle.entity;
 
-import dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,27 +8,25 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "users")
-public class Users {
+@Table(name = "registered_vehicle_photo")
+public class RegisteredVehiclePhoto {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "users_id", nullable = false, unique = true)
+    @Column(name = "registered_vehicle_photo_id", nullable = false)
     private Long id;
 
-    @Column(name = "username", nullable = false, unique = true)
-    private String username;
+    @Column(name = "photo_url", length = 500)
+    @Comment("차량 사진 URL")
+    private String photoUrl;
 
-    @Column(name = "password", nullable = false)
-    private String password;
-
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @Comment("차량 등록 정보")
-    private List<RegisteredVehicle> registeredVehicles;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "registered_vehicle_id", nullable = false)
+    @Comment("차량 등록 테이블 ID")
+    private RegisteredVehicle registeredVehicle;
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/VehicleRegistrationCertificate.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/VehicleRegistrationCertificate.java
@@ -1,6 +1,5 @@
-package dev.kimbank.iload.domain.users.entity;
+package dev.kimbank.iload.domain.vehicle.entity;
 
-import dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -9,27 +8,21 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Setter
 @Entity
-@Table(name = "users")
-public class Users {
+@Table(name = "vehicle_registration_certificate")
+public class VehicleRegistrationCertificate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "users_id", nullable = false, unique = true)
+    @Column(name = "vehicle_registration_certificate_id", nullable = false)
     private Long id;
 
-    @Column(name = "username", nullable = false, unique = true)
-    private String username;
-
-    @Column(name = "password", nullable = false)
-    private String password;
-
-    @OneToMany(mappedBy = "users", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @Comment("차량 등록 정보")
-    private List<RegisteredVehicle> registeredVehicles;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "registered_vehicle_id", nullable = false)
+    @Comment("차량 등록 테이블 ID")
+    private RegisteredVehicle registeredVehicle;
 
     @CreationTimestamp
     @Column(name = "created_at")

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/AccidentInfoEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/AccidentInfoEnum.java
@@ -1,0 +1,20 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AccidentInfoEnum {
+    // 전손 보험사고
+    TOTAL_LOSS("TOTAL_LOSS", "전손 보험사고"),
+    // 침수 보험사고
+    SUBMERGED("SUBMERGED", "침수 보험사고"),
+    // 도난 보험사고
+    STOLEN("STOLEN", "도난 보험사고"),
+    // 기타 보험사고
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ColorEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ColorEnum.java
@@ -1,0 +1,52 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ColorEnum {
+    // 화이트
+    WHITE("WHITE", "화이트"),
+    // 블랙
+    BLACK("BLACK", "블랙"),
+    // 진주색
+    PEARL("PEARL", "진주색"),
+    // 실버
+    SILVER("SILVER", "실버"),
+    // 그레이
+    GRAY("GRAY", "그레이"),
+    // 차콜/쥐색
+    CHARCOAL("CHARCOAL", "차콜/쥐색"),
+    // 네이비
+    NAVY("NAVY", "네이비"),
+    // 빨간색
+    RED("RED", "빨간색"),
+    // 노란색
+    YELLOW("YELLOW", "노란색"),
+    // 초록색
+    GREEN("GREEN", "초록색"),
+    // 파란색
+    BLUE("BLUE", "파란색"),
+    // 연금색
+    LIGHT_GOLD("LIGHT_GOLD", "연금색"),
+    // 갈색
+    BROWN("BROWN", "갈색"),
+    // 금색
+    GOLD("GOLD", "금색"),
+    // 하늘색
+    SKY_BLUE("SKY_BLUE", "하늘색"),
+    // 청옥색
+    TURQUOISE("TURQUOISE", "청옥색"),
+    // 연두색
+    LIGHT_GREEN("LIGHT_GREEN", "연두색"),
+    // 분홍색
+    PINK("PINK", "분홍색"),
+    // 주황색
+    ORANGE("ORANGE", "주황색"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/DriveTypeEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/DriveTypeEnum.java
@@ -1,0 +1,32 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DriveTypeEnum {
+    // 이륜 구동
+    TWO_WD("2WD", "2WD"),
+    // 사륜 구동
+    FOUR_WD("4WD", "4WD"),
+    // 사륜 엔진 사륜구동
+    AWD("AWD", "AWD"),
+    // 전륜 엔진 전륜구동
+    FF("FF", "FF"),
+    // 전륜 엔진 전륜구동
+    FR("FR", "FR"),
+    // 전륜 엔진 후륜구동
+    MR("MR", "MR"),
+    // 후륜 엔진 후륜구동
+    RMR("RMR", "RMR"),
+    // 후륜엔진 후륜구동
+    RR("RR", "RR"),
+    // 후륜구동
+    RWD("RWD", "RWD"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/FuelTypeEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/FuelTypeEnum.java
@@ -1,0 +1,18 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FuelTypeEnum {
+    DIESEL("DIESEL", "경유"),
+    GASOLINE("GASOLINE", "휘발유"),
+    LPG("LPG", "LPG"),
+    ELECTRIC("ELECTRIC", "전기"),
+    HYBRID("HYBRID", "하이브리드"),
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ManufactureCountryEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ManufactureCountryEnum.java
@@ -1,0 +1,17 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ManufactureCountryEnum {
+    KOREA("KOREA", "대한민국"),
+    USA("USA", "미국"),
+    GERMANY("GERMANY", "독일"),
+    JAPAN("JAPAN", "일본"),
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ManufacturerEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/ManufacturerEnum.java
@@ -1,0 +1,26 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ManufacturerEnum {
+    // 기아
+    KIA("KIA", "기아"),
+    // 현대
+    HYUNDAI("HYUNDAI", "현대"),
+    // 제네시스
+    GENESIS("GENESIS", "제네시스"),
+    // 쉐보레
+    CHEVROLET("CHEVROLET", "쉐보레"),
+    // 르노코리아
+    RENAULT_KOREA("RENAULT_KOREA", "르노코리아"),
+    // KG 모빌리티
+    KG_MOBILITY("KG_MOBILITY", "KG 모빌리티"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/OptionInfoEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/OptionInfoEnum.java
@@ -1,0 +1,20 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OptionInfoEnum {
+    // 썬루프
+    SUNROOF("SUNROOF", "썬루프"),
+    // 사이드스탭
+    SIDE_STEP("SIDE_STEP", "사이드스탭"),
+    // 스마트키
+    SMART_KEY("SMART_KEY", "스마트키"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/RepaintedEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/RepaintedEnum.java
@@ -1,0 +1,22 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RepaintedEnum {
+    NOT_REPAINTED("NOT_REPAINTED", "무도색"),
+    // 단순도색
+    REPAINTED_WITH_SIMPLE("REPAINTED_WITH_SIMPLE", "단순도색"),
+    // 판금도색
+    REPAINTED_WITH_BODYWORK("REPAINTED_WITH_BODYWORK", "판금도색"),
+    // 복원도색
+    REPAINTED_WITH_RESTORATION("REPAINTED_WITH_RESTORATION", "복원도색"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/SpecialModificationHistoryEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/SpecialModificationHistoryEnum.java
@@ -1,0 +1,21 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SpecialModificationHistoryEnum {
+    // 연료 개조
+    FUEL_MODIFICATION("FUEL_MODIFICATION", "연료 개조"),
+    // 좌석 개조
+    SEAT_MODIFICATION("SEAT_MODIFICATION", "좌석 개조"),
+    // 엔진 개조
+    ENGINE_MODIFICATION("ENGINE_MODIFICATION", "엔진 개조"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/SpecialUseHistoryEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/SpecialUseHistoryEnum.java
@@ -1,0 +1,20 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SpecialUseHistoryEnum {
+    // 대여 용도
+    RENTAL("RENTAL", "대여 용도"),
+    // 영업 용도
+    COMMERCIAL("COMMERCIAL", "영업 용도"),
+    // 관용 용도
+    OFFICIAL("OFFICIAL", "관용 용도"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/TransmissionEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/TransmissionEnum.java
@@ -1,0 +1,18 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TransmissionEnum {
+    // 자동 변속기
+    AUTOMATIC("AUTOMATIC", "A/T"),
+    // 수동 변속기
+    MANUAL("MANUAL", "M/T"),
+    // 기타
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/VehicleTypeEnum.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/entity/enums/VehicleTypeEnum.java
@@ -1,0 +1,17 @@
+package dev.kimbank.iload.domain.vehicle.entity.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VehicleTypeEnum {
+    CAR("CAR", "자동차"),
+    TRUCK("TRUCK", "트럭"),
+    BUS("BUS", "버스"),
+    MOTORCYCLE("MOTORCYCLE", "오토바이"),
+    OTHER("OTHER", "기타");
+
+    private final String code;
+    private final String description;
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/RegisteredVehiclePhotoRepository.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/RegisteredVehiclePhotoRepository.java
@@ -1,0 +1,7 @@
+package dev.kimbank.iload.domain.vehicle.repository;
+
+import dev.kimbank.iload.domain.vehicle.entity.RegisteredVehiclePhoto;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegisteredVehiclePhotoRepository extends JpaRepository<RegisteredVehiclePhoto, Long> {
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/RegisteredVehicleRepository.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/RegisteredVehicleRepository.java
@@ -1,0 +1,7 @@
+package dev.kimbank.iload.domain.vehicle.repository;
+
+import dev.kimbank.iload.domain.vehicle.entity.RegisteredVehicle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegisteredVehicleRepository extends JpaRepository<RegisteredVehicle, Long> {
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/VehicleQueryRepository.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/VehicleQueryRepository.java
@@ -1,0 +1,71 @@
+package dev.kimbank.iload.domain.vehicle.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dev.kimbank.iload.domain.vehicle.dto.*;
+import dev.kimbank.iload.domain.vehicle.entity.*;
+import jakarta.persistence.EntityManager;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class VehicleQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public VehicleQueryRepository(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    // 최근 등록 차량 조회
+    public List<RegisteredVehicleCardResponse> findLatestRegisteredVehicle() {
+        QRegisteredVehicle registeredVehicle = QRegisteredVehicle.registeredVehicle;
+        QRegisteredVehiclePhoto registeredVehiclePhoto = QRegisteredVehiclePhoto.registeredVehiclePhoto;
+
+        return jpaQueryFactory
+                .select(Projections.constructor(RegisteredVehicleCardResponse.class,
+                        registeredVehicle.id,
+                        registeredVehicle.users.id,
+                        registeredVehicle.users.username,
+                        registeredVehicle.manufacturer,
+                        registeredVehicle.releaseYear,
+                        registeredVehicle.mileage,
+                        registeredVehicle.sellingPrice,
+                        Projections.list(Projections.constructor(RegisteredVehicleCardResponse.RegisteredVehiclePhotoDto.class,
+                                registeredVehiclePhoto.photoUrl
+                        )),
+                        registeredVehicle.createdAt,
+                        registeredVehicle.updatedAt
+                ))
+                .from(registeredVehicle)
+                .leftJoin(registeredVehicle.registeredVehiclePhotos, registeredVehiclePhoto)
+                .orderBy(registeredVehicle.createdAt.desc())
+                .limit(2)
+                .fetch();
+    }
+
+    // 미완성 "등록 차량" 조회
+    public List<RegisterVehicleInProgressCardResponse> findRegisterVehicleInProgressCard(Long userId) {
+        QRegisteredVehicle registeredVehicle = QRegisteredVehicle.registeredVehicle;
+
+        return jpaQueryFactory
+                .select(Projections.constructor(RegisterVehicleInProgressCardResponse.class,
+                        registeredVehicle.id,
+                        registeredVehicle.users.id,
+                        registeredVehicle.users.username,
+                        Expressions.constant(0), // registeredVehicle.progressStep,
+                        Expressions.constant(0), // registeredVehicle.progressTotalSteps,
+                        registeredVehicle.manufacturer,
+                        registeredVehicle.releaseYear,
+                        registeredVehicle.mileage,
+                        registeredVehicle.sellingPrice,
+                        registeredVehicle.createdAt,
+                        registeredVehicle.updatedAt
+                ))
+                .from(registeredVehicle)
+                .where(registeredVehicle.users.id.eq(userId))
+                .orderBy(registeredVehicle.createdAt.desc())
+                .fetch();
+    }
+}

--- a/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/VehicleRegistrationCertificateRepository.java
+++ b/backend/src/main/java/dev/kimbank/iload/domain/vehicle/repository/VehicleRegistrationCertificateRepository.java
@@ -1,0 +1,7 @@
+package dev.kimbank.iload.domain.vehicle.repository;
+
+import dev.kimbank.iload.domain.vehicle.entity.VehicleRegistrationCertificate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VehicleRegistrationCertificateRepository extends JpaRepository<VehicleRegistrationCertificate, Long> {
+}


### PR DESCRIPTION
- 객체 매핑을 위한 ModelMapper 구성
- 동적 쿼리를 위한 QueryDSL 추가
- 등록된 차량에 대한 관계로 사용자 엔티티를 생성
- 차량 관련 API 요청을 처리하기 위한 VehicleController 개발
- 차량 등록과 관련된 비즈니스 로직을 위한 VehicleService 구현
- 차량 등록 및 응답 처리를 위한 DTO를 추가
- JPA 어노테이션이 있는 RegisteredVehicle 및 RegisteredVehiclePhoto 엔티티 생성
- 등록된 차량, 등록된 차량 사진 및 차량 등록 인증서에 대한 리포지토리를 설정
- 제조사, 연료 유형, 색상과 같은 차량 속성에 대한 Enum을 도입
- 등록된 차량과 진행 중인 등록을 가져오는 쿼리 메서드를 구현